### PR TITLE
[Feat/#9] 문제 단건 조회 및 해설 포함 응답 구현

### DIFF
--- a/src/main/java/graduation_project/Dailic/DTO/ProblemDto.java
+++ b/src/main/java/graduation_project/Dailic/DTO/ProblemDto.java
@@ -1,0 +1,46 @@
+package graduation_project.Dailic.DTO;
+
+import graduation_project.Dailic.domain.Problem;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ProblemDto {
+    private Long id;
+    private String questionText; // 문제
+    private List<String> options; //객관식 보기
+    private String correctAnswer; //정답 - withSolution=true 일 때만 포함
+    private String solution; //문제 해설 - withSolution=true 일 때만 포함
+
+    //생성자는 외부에서 직접 사용하지 않도록 private
+    private ProblemDto(Long id, String questionText, List<String> options, String correctAnswer, String solution) {
+        this.id = id;
+        this.questionText = questionText;
+        this.options = options;
+        this.correctAnswer = correctAnswer;
+        this.solution = solution;
+    }
+
+    //Problem 엔티티 객체를 받아서 -> 프론트에서 보기 좋은 형태의 DTO로 변환
+    public static ProblemDto from(Problem problem, boolean withSolution) {
+        List<String> options = new ArrayList<>();
+        // 보기 항목 중 null이 아닌 것만 리스트에 담음 (선택지 개수가 유동적일 경우 대비)
+        if (problem.getOption1() != null) options.add(problem.getOption1());
+        if (problem.getOption2() != null) options.add(problem.getOption2());
+        if (problem.getOption3() != null) options.add(problem.getOption3());
+        if (problem.getOption4() != null) options.add(problem.getOption4());
+        if (problem.getOption5() != null) options.add(problem.getOption5());
+
+        return new ProblemDto(
+                problem.getId(),
+                problem.getQuestionText(),
+                options,
+                withSolution ? problem.getCorrectAnswer() : null,
+                withSolution ? problem.getSolution() : null
+        );
+    }
+}
+
+

--- a/src/main/java/graduation_project/Dailic/controller/ProblemController.java
+++ b/src/main/java/graduation_project/Dailic/controller/ProblemController.java
@@ -1,0 +1,26 @@
+package graduation_project.Dailic.controller;
+
+import graduation_project.Dailic.DTO.ProblemDto;
+import graduation_project.Dailic.service.ProblemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/problems")
+public class ProblemController {
+    private final ProblemService problemService;
+
+    //문제 단건 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<ProblemDto> getProblemById(
+            @PathVariable Long id,
+            @RequestParam(value = "withSolution", defaultValue = "false")
+            boolean whithSolution) {
+        ProblemDto problemDto = problemService.getProblemDtoById(id, whithSolution);
+        return ResponseEntity.ok(problemDto);
+    }
+}

--- a/src/main/java/graduation_project/Dailic/domain/Problem.java
+++ b/src/main/java/graduation_project/Dailic/domain/Problem.java
@@ -21,4 +21,7 @@ public class Problem {
     private String option5;
 
     private String correctAnswer;
+
+    // 해설 필드 추가
+    private String solution;
 }

--- a/src/main/java/graduation_project/Dailic/repository/ProblemRepository.java
+++ b/src/main/java/graduation_project/Dailic/repository/ProblemRepository.java
@@ -2,8 +2,14 @@ package graduation_project.Dailic.repository;
 
 import graduation_project.Dailic.domain.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
-    // Custom query methods can be defined here if needed
-    // For example, find by question text or other attributes
+
+    //랜덤 문제 쿼리
+    @Query(value = "SELECT * FROM problem ORDER BY RAND() LIMIT :count", nativeQuery = true)
+    List<Problem> findRandomProblems(@Param("count") int count);
 }

--- a/src/main/java/graduation_project/Dailic/service/ProblemService.java
+++ b/src/main/java/graduation_project/Dailic/service/ProblemService.java
@@ -1,6 +1,7 @@
 package graduation_project.Dailic.service;
 
 
+import graduation_project.Dailic.DTO.ProblemDto;
 import graduation_project.Dailic.domain.Problem;
 import graduation_project.Dailic.repository.ProblemRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,6 +38,19 @@ public class ProblemService {
     @Transactional
     public void deleteProblem(Long id) {problemRepository.deleteById(id);}
 
+    //DTO 기반 단건 조회 withSolution 처리
+    public ProblemDto getProblemDtoById(Long id, boolean withSolution) {
+        Problem problem = problemRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 문제가 존재하지 않습니다: " + id));
+        return ProblemDto.from(problem, withSolution);
+    }
 
+    //랜덤 문제 DTO 반환 메서드
+    public List<ProblemDto> getRandomProblems(int count) {
+        List<Problem> problems = problemRepository.findRandomProblems(count);
+        return problems.stream()
+                .map(problem->ProblemDto.from(problem, false))
+                .collect(Collectors.toList());
+    }
 }
 


### PR DESCRIPTION
[ PR Title ]
- [[Feat/#9] 문제 단건 조회 및 해설 포함 응답 구현

[ PR Content ]
## Related issue 🛠
- closed #9

## Work Description ✏️
- `GET /problems/{id}`: 문제 단건 조회 API 구현
- `GET /problems/{id}?withSolution=true`: 정답 및 해설 포함 응답
- `ProblemDto`: 응답 필드를 withSolution 여부에 따라 조건부 반환
- 랜덤 문제 추출 메서드 (`getRandomProblems`)는 DailyProblemService 내부에서 활용 가능

## Uncompleted Tasks 😅
- 아직 잘 모르겠음..

## To Reviewers 📢
- Problem 도메인은 문제은행 전용, DailyProblem에서 문제 출제 시 참조
- 랜덤 문제 추출용 컨트롤러는 삭제 가능성 있음 (현재 내부 로직용)